### PR TITLE
Add playlist image caching in IndexedDB

### DIFF
--- a/client/src/components/Playlist.vue
+++ b/client/src/components/Playlist.vue
@@ -2,10 +2,10 @@
   .playlist.pb-4.pa-xs-0
     v-layout.px-4.pt-4.mb-4(row, wrap, align-center)
       v-flex.text-xs-center(xs12, sm3)
-        playlist-artwork.mb-xs-3(:playlist='playlist', elevation='10', size='100%')
+        playlist-artwork.mb-xs-3(v-if='playlist', :playlist='playlist', elevation='10', size='100%')
       v-flex.px-4.text-sm-left.text-xs-center(xs12, sm9)
         .caption PLAYLIST
-        .display-1.mb-2.bold {{ playlist.name }}
+        .display-1.mb-2.bold {{ playlistName }}
         .body-1.grey--text {{ tracks.length }} songs, {{ totalDuration }}
       v-flex.hidden-xs-only(md3, offset-md9, sm6, offset-sm6, xs12)
         v-text-field.filter-field.pt-0(v-model='search', placeholder='Filter', append-icon='search', hide-details)
@@ -45,7 +45,8 @@
           {text: 'ALBUM', value: 'album', align: 'left', sortable: false},
           {text: 'TIME', value: 'duration', align: 'right', sortable: false}
         ],
-        playlist: {images: []},
+        playlist: undefined,
+        playlistName: '',
         tracks: [],
         totalDuration: 0,
         loading: true,
@@ -70,6 +71,7 @@
       this.totalDuration = DateService.englishFormattedDuration(totalMs)
       this.loading = false
       this.audio = new Audio()
+      this.playlistName = this.playlist.name
       this.app.showBackButton = true
     },
     methods: {

--- a/client/src/components/PlaylistArtwork.vue
+++ b/client/src/components/PlaylistArtwork.vue
@@ -8,6 +8,8 @@
 </template>
 
 <script>
+  import ImageCacheService from '../services/ImageCacheService'
+
   export default {
     name: 'playlistArtwork',
     props: {
@@ -15,9 +17,29 @@
       playlist: Object,
       size: String
     },
-    computed: {
-      artworkUrl () {
-        return this.playlist && this.playlist.images && this.playlist.images.length && this.playlist.images[0].url
+    data () {
+      return {
+        artworkUrl: false
+      }
+    },
+    created () {
+      const key = this.playlist && this.playlist.images && this.playlist.images.length && this.playlist.images[0].url
+
+      if (key) {
+        ImageCacheService.getObjectURL(key).then(objectURL => {
+          if (objectURL) {
+            // We were able to store stuff in the db, use the object URL
+            console.log('Got objectURL from ImageCacheService:', objectURL)
+            this.artworkUrl = objectURL
+          } else {
+            // in this case, it's better to use the existing URL and fall back on normal image loading
+            console.log('Didn\'t get anything back from ImageCacheService')
+            this.artworkUrl = key
+          }
+        })
+      } else {
+        console.log('The playlist we had didn\'t have an image.')
+        this.artworkUrl = false
       }
     }
   }

--- a/client/src/components/PlaylistArtwork.vue
+++ b/client/src/components/PlaylistArtwork.vue
@@ -1,6 +1,7 @@
 <template lang="pug">
   .playlist-artwork.mx-auto(v-ripple='{ class: "white--text" }', :class='[`elevation-${elevation || 5}`]', :style='{width: size, height: size}')
-    img(v-if='artworkUrl', :src='artworkUrl')
+    lazy-component(@show='init')
+      img(v-if='artworkUrl', :src='artworkUrl')
     img(v-if='!artworkUrl', src='/static/transparent-square.png')
     .no-image.grey.darken-3.text-xs-center(v-if='!isFolder && !artworkUrl', :style='{width: size, height: size, "line-height": size}')
       .no-image-icon-container
@@ -12,7 +13,6 @@
 
 <script>
   import ImageCacheService from '../services/ImageCacheService'
-
   export default {
     name: 'playlistArtwork',
     props: {
@@ -32,9 +32,6 @@
         this.init()
       }
     },
-    mounted () {
-      this.init()
-    },
     methods: {
       init () {
         const key = (this.libraryPlaylist && this.libraryPlaylist.data && this.libraryPlaylist.data.artworkUrl) ||
@@ -43,17 +40,12 @@
         if (key) {
           ImageCacheService.getObjectURL(key).then(objectURL => {
             if (objectURL) {
-              // We were able to store stuff in the db, use the object URL
-              console.log('Got objectURL from ImageCacheService:', objectURL)
               this.artworkUrl = objectURL
             } else {
-              // in this case, it's better to use the existing URL and fall back on normal image loading
-              console.log('Didn\'t get anything back from ImageCacheService')
               this.artworkUrl = key
             }
           })
         } else {
-          console.log('The playlist we had didn\'t have an image.')
           this.artworkUrl = false
         }
       }

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -30,6 +30,7 @@ import router from './router'
 import {Ripple} from 'vuetify/es5/directives'
 import './common.css'
 import './sl-vue-tree.css'
+import VueLazyload from 'vue-lazyload'
 
 Vue.use(Vuetify, {
   components: {
@@ -60,6 +61,11 @@ Vue.use(Vuetify, {
   theme: {
     primary: '#1db954'
   }
+})
+
+Vue.use(VueLazyload, {
+  preLoad: 2.0,
+  lazyComponent: true
 })
 
 Vue.config.productionTip = false

--- a/client/src/services/ImageCacheService.js
+++ b/client/src/services/ImageCacheService.js
@@ -4,16 +4,12 @@ const indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexe
 const dbVersion = 1.0
 
 class ImageCacheService extends BaseService {
-  // returns promise for now
   static getObjectURL (key) {
-    // giving it a name so we can recur
     const promiseFunction = async resolve => {
-      var request = indexedDB.open('imageFiles', dbVersion)
-      var db
+      const request = indexedDB.open('imageFiles', dbVersion)
+      let db
 
       const createObjectStore = function (dataBase) {
-        // Create an objectStore
-        console.log('Creating objectStore')
         dataBase.createObjectStore('images')
       }
 
@@ -22,79 +18,42 @@ class ImageCacheService extends BaseService {
       }
 
       const attemptLoadFromDatabase = (success, failure) => {
-        // Open a transaction to the database
         const transaction = db.transaction(['images'], 'readonly')
-        console.log('attempting to load from database')
-
-        // Retrieve the file that was just stored
         const request = transaction.objectStore('images').get(key)
         request.onsuccess = function (event) {
-          var imgFile = event.target.result
-          console.log('Got image!' + imgFile)
-
+          const imgFile = event.target.result
           if (imgFile) {
-            // Get window.URL object
-            var URL = window.URL || window.webkitURL
-
-            // Create and revoke ObjectURL
-            var imgURL = URL.createObjectURL(imgFile)
-
-            console.log('loaded from db successfully')
+            const URL = window.URL || window.webkitURL
+            const imgURL = URL.createObjectURL(imgFile)
             success(imgURL)
           } else {
             failure()
           }
         }
-
         request.onerror = failure
       }
 
       const getImageFileFromServer = function () {
-        console.log('unable to load from db. trying server load')
-
-        // Create XHR
-        var xhr = new XMLHttpRequest()
-        var blob
-
+        const xhr = new XMLHttpRequest()
+        let blob
         xhr.open('GET', key, true)
-        // Set the responseType to blob
         xhr.responseType = 'blob'
-
         xhr.addEventListener('load', function () {
           if (xhr.status === 200) {
-            console.log('Image retrieved')
-
-            // Blob as response
             blob = xhr.response
-            console.log('Blob:' + blob)
-
-            // Put the received blob into IndexedDB
             putImageInDatabase(blob)
           }
         }, false)
-        // Send XHR
         xhr.send()
       }
 
       const putImageInDatabase = function (blob) {
-        console.log('Putting images in IndexedDB')
-
-        // Open a transaction to the database
-        var transaction = db.transaction(['images'], 'readwrite')
-
-        // Put the blob into the dabase
+        const transaction = db.transaction(['images'], 'readwrite')
         transaction.objectStore('images').put(blob, key)
-
-        // Retrieve the file that was just stored
         transaction.objectStore('images').get(key).onsuccess = function (event) {
-          var imgFile = event.target.result
-
-          // Get window.URL object
-          var URL = window.URL || window.webkitURL
-
-          // Create and revoke ObjectURL
-          var imgURL = URL.createObjectURL(imgFile)
-
+          const imgFile = event.target.result
+          const URL = window.URL || window.webkitURL
+          const imgURL = URL.createObjectURL(imgFile)
           resolve(imgURL)
         }
       }
@@ -104,7 +63,6 @@ class ImageCacheService extends BaseService {
       }
 
       request.onsuccess = function (event) {
-        console.log('Success creating/accessing IndexedDB database', event)
         db = request.result
 
         db.onerror = function (event) {
@@ -115,7 +73,7 @@ class ImageCacheService extends BaseService {
         // Interim solution for Google Chrome to create an objectStore. Will be deprecated
         if (db.setVersion) {
           if (db.version !== dbVersion) {
-            var setVersion = db.setVersion(dbVersion)
+            const setVersion = db.setVersion(dbVersion)
             setVersion.onsuccess = function () {
               createObjectStore(db)
               getImageFile()
@@ -133,7 +91,6 @@ class ImageCacheService extends BaseService {
         createObjectStore(event.target.result)
       }
     }
-    // This promise lets us pretend to return in the 'ready' event.
     return new Promise(promiseFunction)
   }
 }

--- a/client/src/services/ImageCacheService.js
+++ b/client/src/services/ImageCacheService.js
@@ -32,14 +32,18 @@ class ImageCacheService extends BaseService {
           var imgFile = event.target.result
           console.log('Got image!' + imgFile)
 
-          // Get window.URL object
-          var URL = window.URL || window.webkitURL
+          if (imgFile) {
+            // Get window.URL object
+            var URL = window.URL || window.webkitURL
 
-          // Create and revoke ObjectURL
-          var imgURL = URL.createObjectURL(imgFile)
+            // Create and revoke ObjectURL
+            var imgURL = URL.createObjectURL(imgFile)
 
-          console.log('loaded from db successfully')
-          success(imgURL)
+            console.log('loaded from db successfully')
+            success(imgURL)
+          } else {
+            failure()
+          }
         }
 
         request.onerror = failure

--- a/client/src/services/ImageCacheService.js
+++ b/client/src/services/ImageCacheService.js
@@ -1,0 +1,138 @@
+import BaseService from './BaseService'
+
+const indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.OIndexedDB || window.msIndexedDB
+const dbVersion = 1.0
+
+class ImageCacheService extends BaseService {
+  // returns promise for now
+  static getObjectURL (key) {
+    // giving it a name so we can recur
+    const promiseFunction = async resolve => {
+      var request = indexedDB.open('imageFiles', dbVersion)
+      var db
+
+      const createObjectStore = function (dataBase) {
+        // Create an objectStore
+        console.log('Creating objectStore')
+        dataBase.createObjectStore('images')
+      }
+
+      const getImageFile = () => {
+        attemptLoadFromDatabase(resolve, getImageFileFromServer)
+      }
+
+      const attemptLoadFromDatabase = (success, failure) => {
+        // Open a transaction to the database
+        const transaction = db.transaction(['images'], 'readonly')
+        console.log('attempting to load from database')
+
+        // Retrieve the file that was just stored
+        const request = transaction.objectStore('images').get(key)
+        request.onsuccess = function (event) {
+          var imgFile = event.target.result
+          console.log('Got image!' + imgFile)
+
+          // Get window.URL object
+          var URL = window.URL || window.webkitURL
+
+          // Create and revoke ObjectURL
+          var imgURL = URL.createObjectURL(imgFile)
+
+          console.log('loaded from db successfully')
+          success(imgURL)
+        }
+
+        request.onerror = failure
+      }
+
+      const getImageFileFromServer = function () {
+        console.log('unable to load from db. trying server load')
+
+        // Create XHR
+        var xhr = new XMLHttpRequest()
+        var blob
+
+        xhr.open('GET', key, true)
+        // Set the responseType to blob
+        xhr.responseType = 'blob'
+
+        xhr.addEventListener('load', function () {
+          if (xhr.status === 200) {
+            console.log('Image retrieved')
+
+            // Blob as response
+            blob = xhr.response
+            console.log('Blob:' + blob)
+
+            // Put the received blob into IndexedDB
+            putImageInDatabase(blob)
+          }
+        }, false)
+        // Send XHR
+        xhr.send()
+      }
+
+      const putImageInDatabase = function (blob) {
+        console.log('Putting images in IndexedDB')
+
+        // Open a transaction to the database
+        var transaction = db.transaction(['images'], 'readwrite')
+
+        // Put the blob into the dabase
+        transaction.objectStore('images').put(blob, key)
+
+        // Retrieve the file that was just stored
+        transaction.objectStore('images').get(key).onsuccess = function (event) {
+          var imgFile = event.target.result
+          console.log('Got elephant!' + imgFile)
+
+          // Get window.URL object
+          var URL = window.URL || window.webkitURL
+
+          // Create and revoke ObjectURL
+          var imgURL = URL.createObjectURL(imgFile)
+
+          resolve(imgURL)
+        }
+      }
+
+      request.onerror = function (event) {
+        console.log('Error creating/accessing IndexedDB database', event)
+      }
+
+      request.onsuccess = function (event) {
+        console.log('Success creating/accessing IndexedDB database', event)
+        db = request.result
+
+        db.onerror = function (event) {
+          console.log('Error creating/accessing IndexedDB database', event)
+        }
+
+        // TODO investigate whether we really need this
+        // Interim solution for Google Chrome to create an objectStore. Will be deprecated
+        if (db.setVersion) {
+          if (db.version !== dbVersion) {
+            var setVersion = db.setVersion(dbVersion)
+            setVersion.onsuccess = function () {
+              createObjectStore(db)
+              getImageFile()
+            }
+          } else {
+            getImageFile()
+          }
+        } else {
+          getImageFile()
+        }
+      }
+
+      // For future use. Currently only in latest Firefox versions
+      request.onupgradeneeded = function (event) {
+        createObjectStore(event.target.result)
+      }
+    }
+    // This promise lets us pretend to return in the 'ready' event.
+    return new Promise(promiseFunction)
+  }
+}
+
+export default ImageCacheService

--- a/package-lock.json
+++ b/package-lock.json
@@ -10073,6 +10073,11 @@
         "async": "1.5.2"
       }
     },
+    "vue-lazyload": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/vue-lazyload/-/vue-lazyload-1.2.6.tgz",
+      "integrity": "sha512-6a61+pzwcfowhLRQiPdmRuJ40n/4fL/sEynu8KQZoCf5RVA0NH0X68vplLY0+lUM8mKNScYomaepV+hdjgnZhg=="
+    },
     "vxx": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/vxx/-/vxx-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "serve-favicon": "^2.0.1",
     "sl-vue-tree": "^1.6.0",
     "spotify-web-api-node": "^2.5.0",
-    "strong-error-handler": "^2.0.0"
+    "strong-error-handler": "^2.0.0",
+    "vue-lazyload": "^1.2.6"
   },
   "devDependencies": {
     "eslint": "^3.19.0",


### PR DESCRIPTION
# Image Caching

When navigating the same list of playlists over and over, why should we use the internet to pull the images every time?

## IndexedDB

This example is built from the [Mozilla example](https://hacks.mozilla.org/2012/02/storing-images-and-files-in-indexeddb/) where they cache a single image (and revoke immediately afterward.) The basic idea is:

1. Load an image using XMLHttpRequest
2. Once you have the blob, open a database transaction and insert the blob
3. Execute a load to get the blob back from the database
4. Use URL.createObjectURL on the blob from the database 
5. Use with `<img src="objectURL"/>`

## Modifications

First off, I changed the algorithm to use a key parameter, then used the URL from the Spotify service as the key. That way the keys are the same keys used against Spotify's image CDN. If those CDN links change, our key will no longer be valid and this app will request a new image from the CDN and store under the updated key. 

Second, I added a check to the database for the keys before making the XMLHttpRequest to the CDN. There's not much point in having them in the database without the check.

Third and final, I had to adjust the way the `Playlist` component loaded the `PlaylistArtwork` component. I couldn't get the image to load when the `PlaylistArtwork` component rendered with an `undefined` passed in for the playlist. Any suggestions here would be welcome :)